### PR TITLE
Initialize arrays to prevent values filled from previous jobs/vm

### DIFF
--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -468,11 +468,11 @@ function backup(){
             continue
         fi
 
-        local -a export_image_spec
-        local -a export_current_snap
-        local -a export_backup_file
-        local -a export_latest_snap
-        local -a export_type
+        local -a export_image_spec=()
+        local -a export_current_snap=()
+        local -a export_backup_file=()
+        local -a export_latest_snap=()
+        local -a export_type=()
         local -i export_idx=0
 
         local image_spec


### PR DESCRIPTION
Hey There, 

this Pull request tries to address the following scenario:

Backup of 2 vms.
The first vm has multiple disks. 
The second vm has exactly one disk. 

The backup from the first vm is created successfully. 
The backup job from the second vm fails to backup disk no2 which indeed doesnt exists. The backup paths are still filled from the values of the first vm backup job

relates to #21 