### PR TITLE
Fix bug in restore routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Whit parameter **--unprotect-snap** is possible to disable snapshot protection.
 
 ## Configuration and use
 
+If you want to use pigz compression which is recommended, install the package:
+
+```apt install pigz```
+
+If you want to use InfluxDB Metric reporting, install Curl:
+
+``` apt install curl```
+
 Download package eve4pve-barc\_?.?.?-?\_all.deb, on your Proxmox VE host and
 install:
 

--- a/README.md
+++ b/README.md
@@ -126,15 +126,17 @@ snapshos it knows**.
 
 Whit parameter **--unprotect-snap** is possible to disable snapshot protection.
 
-## Configuration and use
+## Installation of prerequisites
 
 If you want to use pigz compression which is recommended, install the package:
 
-```apt install pigz```
+```apt install pigz curl```
 
-If you want to use InfluxDB Metric reporting, install Curl:
+## Configuration and use
 
-``` apt install curl```
+There are two ways to use this tool: as APT package or from the Git repository. The Releases are always a little bit behind.
+
+#### APT
 
 Download package eve4pve-barc\_?.?.?-?\_all.deb, on your Proxmox VE host and
 install:
@@ -144,7 +146,42 @@ wget https://github.com/EnterpriseVE/eve4pve-barc/releases/download/?.?.?/eve4pv
 dpkg -i eve4pve-barc_?.?.?-?_all.deb
 ```
 
-This tool need basically no configuration.
+#### From Git:
+
+Map the network share you want the backups to be written to via nfs or cifs. I would recommend to place the backuptool on that share so you have it available if one node fails, otherwise you would have to install it to every node.
+
+```sh
+apt -y install git
+```
+
+Find out where your share is mounted, and change to that directory (this is usually in /mnt/pve):
+
+```sh
+cd /mnt/pve/backup
+```
+
+Create a directory where the backups shall live:
+
+```sh
+mkdir barc && cd barc
+```
+
+Clone the Git repo
+
+```sh
+git clone https://github.com/Corsinvest/cv4pve-barc
+```
+
+Pick a release
+```sh
+git checkout 0.2.5-renew
+```
+
+So you want to change to that directory or use the script with it's full path, eg 
+
+```sh
+/mnt/pve/backup/barc/cv4pve-barc/eve4pve-barc --help
+```
 
 ## Things to check
 

--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -4,7 +4,7 @@
 # Author: Daniele Corsini <daniele.corsini@enterpriseve.com>
 #         Bastian Mäuser <bma@netz.org>        
 
-declare -r VERSION=0.2.4-renew
+declare -r VERSION=0.2.5-renew
 declare -r NAME=$(basename "$0")
 declare -r PROGNAME=${NAME%.*}
 

--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -1163,6 +1163,7 @@ function restore(){
         regex='^([0-9]+)([a-zA-Z-]+)\.(.*)\.(diff|img).?(.*)?'
         [[ "$image" =~ $regex ]]
         searchdisk=${BASH_REMATCH[3]}
+        searchpool=${BASH_REMATCH[2]}
         local inchain=false
         local -a plan
         for backup_files in $(ls -r "$path_backup/"*{$EXT_IMAGE,$EXT_DIFF}{,.gz,.zz,.bz2} 2>/dev/null|xargs -n1 basename); do
@@ -1171,9 +1172,10 @@ function restore(){
             fi
             if [ "$inchain" == true ]; then
                 [[ "$backup_files" =~ $regex ]]
+                foundpool=${BASH_REMATCH[2]}
                 founddisk=${BASH_REMATCH[3]}
                 ext=${BASH_REMATCH[4]}
-                if [ "$founddisk" == "$searchdisk" ]; then
+                if [ "$founddisk" == "$searchdisk" ] && [ "$foundpool" == "$searchpool" ]; then
                     plan=("$backup_files" "${plan[@]}")
                     if [[ "$ext" == "img" ]]; then
                         break


### PR DESCRIPTION
Fixes bug in restore routine, that caused the restore chain to be planned faulty because it did not filter for the pool name. Occured if a VM had two disks with the same name in different pools, eg. ssd-pool/vm-100-disk-0 and hdd-pool/vm-100-disk-0