### PR TITLE
Fix backup & restore checksum issues with keep & renew

### DIFF
--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -139,7 +139,7 @@ Options:
                          'storage-???' storage Proxmox VE (pool Ceph)
     --label              Is usually 'hourly', 'daily', 'weekly', or 'monthly'
     --path               Path destination backup
-    --keep               Specify the number of differential backup which should will keep, (default: 1)
+    --keep               Specify the number of differential backups which should will keep, (default: 1)
     --renew              Specify how many diffs may accumulate, until a full Backup is issued
                          --renew=10 for keeping 10 Diffs until making a new full export
                          --renew=7d for making diffs up to 7 days, until making a new full export
@@ -1048,7 +1048,7 @@ function merge_diff_backup(){
             export_diff=$(printf %q "$export_diff")
             log debug "*** Export file is: $export_diff"
             
-            # check the export diff exists
+            # check the export diff exists (i.e. make sure we have a valid file path)
             if [[ -f "$export_diff" ]]; then
 			    log debug "$export_diff exists."
 			else
@@ -1122,30 +1122,9 @@ function merge_diff_backup(){
                             do_run "rm $first_diff.*"
                         fi
 
-                        # remove the additional meta data files related to the 2nd diff, as they are no longer correct (e.g. checkums)
-                        #log info "VM $vm_id - Removing second diff backup '$second_diff'"
-                        #if do_run "rm $second_diff" ; then
-                        #    log debug "Removed old diff file."
-                            #do_run "find . -type f -name '$second_diff.*' -delete"
-                        #    do_run "rm $second_diff.*"
-                        #fi
-
                         # rename new merge in second_diff
                         log debug "Renaming merged diff to 2nd diff filename. ($merged_diff to $second_diff)"
                         do_run "mv '$merged_diff' '$second_diff'"
-                        
-                        # recreate files
-                        #if [ "$opt_cksum" == true ]; then
-                       	#    log debug "COMPRESS: $compress, CKEXT: ${ckext[$opt_ckmethod]}"
-                        #    cmd="$compress $merged_diff | tee >($compress > '$second_diff') >(wc -c > $second_diff.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $second_diff.${ckext[$opt_ckmethod]}"
-                        #    log debug "Running: $cmd"
-                        #    if ! do_run $cmd ; then
-                        #	    log error "Failed to create checksum files."
-                        #    fi
-                        #fi
-                        
-                        # remove temporary merge_diff file
-                        #do_run "rm '$merged_diff'"
 
                         #remove config
                         local tms_first_diff; tms_first_diff=$(basename "$first_diff" | awk '{print substr($1,1,14)}')

--- a/eve4pve-barc
+++ b/eve4pve-barc
@@ -139,7 +139,7 @@ Options:
                          'storage-???' storage Proxmox VE (pool Ceph)
     --label              Is usually 'hourly', 'daily', 'weekly', or 'monthly'
     --path               Path destination backup
-    --keep               Specify the number of backup which should will keep, (default: 1)
+    --keep               Specify the number of differential backup which should will keep, (default: 1)
     --renew              Specify how many diffs may accumulate, until a full Backup is issued
                          --renew=10 for keeping 10 Diffs until making a new full export
                          --renew=7d for making diffs up to 7 days, until making a new full export
@@ -824,7 +824,7 @@ function backup(){
 
                 log info "VM $vm_id - Export initial '$backup_file'"
                 if [ "$opt_cksum" == true ]; then
-                    excmd="rbd export --rbd-concurrent-management-ops $opt_iothreads $current_snap - | tee >($compress > '$backup_file') | tee >({ wc -c; } > $backup_file.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $backup_file.${ckext[$opt_ckmethod]}"
+                    excmd="rbd export --rbd-concurrent-management-ops $opt_iothreads $current_snap - | tee >($compress > '$backup_file') >({ wc -c; } > $backup_file.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $backup_file.${ckext[$opt_ckmethod]}"
                 else
                     excmd="rbd export --rbd-concurrent-management-ops $opt_iothreads $current_snap '$backup_file'"
                 fi
@@ -852,7 +852,7 @@ function backup(){
                 call_hook_script "export-diff-pre" "$current_snap" "$backup_file"
                 log info "VM $vm_id - Export diff '$backup_file'"
                 if [ "$opt_cksum" == true ]; then
-                    excmd="rbd export-diff --from-snap $latest_snap $current_snap - | tee >($compress > '$backup_file') | tee >({ wc -c; } > $backup_file.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $backup_file.${ckext[$opt_ckmethod]}"
+                    excmd="rbd export-diff --from-snap $latest_snap $current_snap - | tee >($compress > '$backup_file') >({ wc -c; } > $backup_file.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $backup_file.${ckext[$opt_ckmethod]}"
                 else
                     excmd="rbd export-diff --from-snap $latest_snap $current_snap '$backup_file'"
                 fi
@@ -934,6 +934,7 @@ function housekeeping() {
     if [[ $opt_retain =~ $retime ]]; then
         maxage=$((${BASH_REMATCH[1]}*$factor))
         for image in $(ls -r $path_backup/*{$EXT_DIFF,$EXT_IMAGE}{.zz,.gz,.bz2,} 2>/dev/null); do
+            log debug "Image: $image"
             if [[ "$image" =~ $reimg ]]; then
                 ext=${BASH_REMATCH[4]}
                 ts=${BASH_REMATCH[1]}
@@ -962,6 +963,7 @@ function housekeeping() {
         done
     elif [[ $opt_retain =~ $renum ]]; then
         for image in $(ls -r $path_backup/*{$EXT_DIFF,$EXT_IMAGE}{.zz,.gz,.bz2,} 2>/dev/null); do
+            log debug "Image: $image"
             if [[ "$image" =~ $reimg ]]; then
                 filecount=$((filecount+1))
                 ext=${BASH_REMATCH[4]}
@@ -985,13 +987,51 @@ function housekeeping() {
 }
 
 function merge_diff_backup(){
-    #loop all image
+    
     local image=''
-    for image in $path_backup/*$EXT_IMAGE; do
-        image=$(basename "$image")
+    
+    # set the de/compression command & extension
+    needs_decompress=true
+    case "$opt_compress" in
+        "none" )
+            cext=""
+            compress="cat"
+            decompress="cat"
+            needs_decompress=false
+            ;;
+        "gzip" )
+            cext=".gz"
+            compress="gzip"
+            decompress="gunzip -c"
+            ;;
+        "bzip2" )
+            cext=".bz2"
+            compress="bzip2"
+            decompress="bzip2 -d"
+            ;;
+        "pigz" )
+            cext=".zz"
+            compress="pigz -3 -p $opt_compressthreads"
+            decompress="pigz -dc -p $opt_compressthreads"
+            ;;
+    esac
+    log debug "cext: $cext"
+    log debug "compress: $compress"
+    log debug "decompress: $decompress"
 
+	#loop all images
+    for image in $path_backup/*$EXT_IMAGE$cext; do
+        image=$(basename "$image")
+        log debug "Image is: $image"
+
+        # we want just the Ceph pool name & disk name from the filename
+        # e.g. 20201005174303ceph_container_pool.vm-107-disk-0.img.zz becomes ceph_container_pool.vm-107-disk-0, so
+        # 1st cut off the timestamp prefix from the image filename (always 14 charaters long)
         local suffix_backup_file=${image:14}
-        suffix_backup_file=${suffix_backup_file%.*}
+        log debug "Suffix of backup file 1st filter pass: $suffix_backup_file"
+        # 2nd cut off the suffix from .img onwards (can have multiple file extension variations e.g. .img, .img.zz, img.gzip, etc.)
+        suffix_backup_file=${suffix_backup_file%\.img*}
+        log debug "Suffix of backup file. 2nd filter pass: $suffix_backup_file"
 
         local first_diff=''
         local second_diff=''
@@ -999,29 +1039,117 @@ function merge_diff_backup(){
 
         #loop diff
         local export_diff=''
-        for export_diff in $(ls -r "$path_backup/"*$suffix_backup_file$EXT_DIFF 2>/dev/null); do
+        log debug "path_backup: $path_backup"
+        log debug "for path: $path_backup/"*$suffix_backup_file$EXT_DIFF$cext
+        for export_diff in $(ls -r "$path_backup/"*$suffix_backup_file$EXT_DIFF$cext 2>/dev/null); do
+            # iterates diff files from oldest to newest
+            
+            # clean up export file path
+            export_diff=$(printf %q "$export_diff")
+            log debug "*** Export file is: $export_diff"
+            
+            # check the export diff exists
+            if [[ -f "$export_diff" ]]; then
+			    log debug "$export_diff exists."
+			else
+			    log error "Export file not found. Aborting..."
+			    exit 2
+			fi
+            
+            # are we at a diff count higher or equal to our 'keep' level?
             if [ "$index" -ge "$opt_keep" ]; then
                 if [ -z "$second_diff" ]; then
-                    second_diff="$export_diff"
+                    # 1st iteration
+                    second_diff=$(printf %q "$export_diff")
                 else
-                    first_diff="$export_diff"
+                    first_diff=$(printf %q "$export_diff")
                     merged_diff="$second_diff-merged"
+                    
+                    # should never happen, but extra safety check
+                    if [ -z "$first_diff" ] || [ -z "$second_diff" ]; then
+                        # for some reason we're missing a diff file path. This could be dangerous with later rm commands so abort.
+                        debug error "One or both diff path/s missing. Aborting!"
+                        return 3
+                    fi
+                    
+                    # define initial merge file paths
+                    merge_file_1=$first_diff
+                    merge_file_2=$second_diff
+                    
+                    # check if we have files that need decompressing
+                    if [ "$needs_decompress" == true ]; then
+                    
+	                    # decompress the 1st diff files
+	                    cmd="$decompress $first_diff > $first_diff.raw"
+	                    log debug "Decompressing 1st diff file: $cmd"
+	                    if ! do_run $cmd ; then
+	                        log error "Failed to decompress 1st diff file. Aborting."
+	                        exit 4
+	                    fi
+	                    
+	                    # decompress the 2nd diff files
+	                    cmd="$decompress $second_diff > $second_diff.raw"
+	                    log debug "Decompressing 2nd diff file: $cmd"
+	                    if ! do_run $cmd ; then
+	                        log error "Failed to decompress 2nd diff file. Aborting."
+	                        exit 5
+	                    fi
+	                    
+	                    # redefine the merge file paths for the later diff merge operation
+	                    merge_file_1=$first_diff.raw
+                    	merge_file_2=$second_diff.raw
+	                
+	                fi
 
-                    log info "VM $vm_id - Merge diff backup '$(basename "$first_diff")' '$(basename "$second_diff")'"
-
-                    if do_run "rbd merge-diff '$first_diff' '$second_diff' '$merged_diff'"; then
+                    # merge 1st (older) & 2nd (more recent) diffs into a new diff file with a filename based on newer 2nd diff
+                    # we also create the checksum & size meta data files at this time, writing over the old ones
+                    log info "VM $vm_id - Merge diff backup '$(basename "$first_diff")' '$(basename "$second_diff")' to '$(basename "$merged_diff")'"
+                    if do_run "rbd merge-diff $merge_file_1 $merge_file_2 - | tee >($compress > $merged_diff) >(wc -c > $second_diff.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $second_diff.${ckext[$opt_ckmethod]}" ; then
+                        
                         #ok result
-                        log info "VM $vm_id - Removing backup '$first_diff'";
-                        do_run "rm '$first_diff'"
+                        
+                        if [ "$needs_decompress" == true ]; then
+	                        # remove the temporary decompressed diff files
+	                        if ! do_run "rm $first_diff.raw $second_diff.raw" ; then
+	                            log error "Failed to remove temporary diff files."
+	                        fi
+	                    fi
+	                    
+	                    # clean up the 1st diff files that we no longer need, as it's merged into the 2nd diff
+	                    log info "VM $vm_id - Removing first diff backup '$first_diff'";
+                        if do_run "rm $first_diff" ; then
+                            log debug "First diff removed. Removing meta files..."
+                            do_run "rm $first_diff.*"
+                        fi
 
-                        log info "VM $vm_id - Removing backup '$second_diff'"
-                        do_run "rm '$second_diff'"
+                        # remove the additional meta data files related to the 2nd diff, as they are no longer correct (e.g. checkums)
+                        #log info "VM $vm_id - Removing second diff backup '$second_diff'"
+                        #if do_run "rm $second_diff" ; then
+                        #    log debug "Removed old diff file."
+                            #do_run "find . -type f -name '$second_diff.*' -delete"
+                        #    do_run "rm $second_diff.*"
+                        #fi
 
-                        #rename new merge in second_diff
+                        # rename new merge in second_diff
+                        log debug "Renaming merged diff to 2nd diff filename. ($merged_diff to $second_diff)"
                         do_run "mv '$merged_diff' '$second_diff'"
+                        
+                        # recreate files
+                        #if [ "$opt_cksum" == true ]; then
+                       	#    log debug "COMPRESS: $compress, CKEXT: ${ckext[$opt_ckmethod]}"
+                        #    cmd="$compress $merged_diff | tee >($compress > '$second_diff') >(wc -c > $second_diff.${ckext[$opt_ckmethod]}.size) | $opt_ckmethod > $second_diff.${ckext[$opt_ckmethod]}"
+                        #    log debug "Running: $cmd"
+                        #    if ! do_run $cmd ; then
+                        #	    log error "Failed to create checksum files."
+                        #    fi
+                        #fi
+                        
+                        # remove temporary merge_diff file
+                        #do_run "rm '$merged_diff'"
 
                         #remove config
-                        local tms_first_diff; tms_first_diff=$(basename "$first_diff" | awk '{print substr($1,1,12)}')
+                        local tms_first_diff; tms_first_diff=$(basename "$first_diff" | awk '{print substr($1,1,14)}')
+                        log debug "Removing the following conf file: '$path_backup/$tms_first_diff$EXT_CONF'"
                         do_run "rm -f '$path_backup/$tms_first_diff$EXT_CONF'"
 
                         #remove firewall
@@ -1034,6 +1162,11 @@ function merge_diff_backup(){
                         #Error
                         log error "VM $vm_id - Merge diff backup '$(basename $first_diff)' '$(basename $second_diff)' to '$(basename "$merged_diff")'"
                         do_run "rm -f $merged_diff"
+                        
+                        if [ "$needs_decompress" == true ]; then
+	                        # remove the temporary decompressed diff files
+	                        do_run "rm $first_diff.raw $second_diff.raw"
+	                    fi
 
                         return 1
                     fi
@@ -1202,6 +1335,8 @@ function restore(){
                     ;;
             esac
             local streamcksum
+            log debug "ext: $ext"
+            log debug "cext: $cext"
             case ".$ext" in
                 "$EXT_IMAGE" )
                     log info "Initial import $backup"
@@ -1224,7 +1359,7 @@ function restore(){
                     ;;
                 "$EXT_DIFF" )
                     log info "Differential $backup"
-                    cmd="$compress '$path_backup/$backup' | tee >(rbd import-diff --no-progress - $pool_name/$name_import) | $opt_ckmethod "
+                    cmd="$compress '$path_backup/$backup' | tee >(rbd import-diff --no-progress - $pool_name/$name_import) | $opt_ckmethod"
                     log info "VM $vm_id - importcmd: $cmd"
                     streamcksum=$(eval "$cmd")
                     if [ -e "$path_backup/$backup.${ckext[$opt_ckmethod]}" ]; then


### PR DESCRIPTION
These fixes should restore functionality to the app & clear up most currently open issues.
There were problems with the checksumming operations being performed in different ways within the backup, restore & differential merging functions, which would lead to failed restores.
Also, the diff merging routines did not take into consideration the new compression formats, thus were not working.